### PR TITLE
Fix React module loading via importmap

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,9 +5,16 @@
     <title>Asymmetric Effort</title>
     <link rel="icon" href="favicon.ico" />
     <link rel="stylesheet" href="css/index.css" />
-    <script src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-    <script src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-    <script src="https://unpkg.com/react-router-dom@6/umd/react-router-dom.production.min.js"></script>
+    <!-- Import map resolving React packages to CDN-hosted ES modules -->
+    <script type="importmap">
+      {
+        "imports": {
+          "react": "https://esm.sh/react@18",
+          "react-dom/client": "https://esm.sh/react-dom@18/client",
+          "react-router-dom": "https://esm.sh/react-router-dom@6"
+        }
+      }
+    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- add an import map to load React, ReactDOM and React Router from a CDN

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68858c67adfc8332876c5b45b6812914