### PR TITLE
Fix module path extensions for browser imports

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -2,16 +2,16 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { HashRouter, Routes, Route } from 'react-router-dom';
-import Header from './components/Header';
-import Navbar from './components/Navbar';
-import Footer from './components/Footer';
-import Home from './pages/Home';
-import About from './pages/About';
-import Blog from './pages/Blog';
-import Contact from './pages/Contact';
-import GreyNet from './projects/GreyNet';
-import CryptoTap from './projects/CryptoTap';
-import Gremlin from './projects/Gremlin';
+import Header from './components/Header.js';
+import Navbar from './components/Navbar.js';
+import Footer from './components/Footer.js';
+import Home from './pages/Home.js';
+import About from './pages/About.js';
+import Blog from './pages/Blog.js';
+import Contact from './pages/Contact.js';
+import GreyNet from './projects/GreyNet.js';
+import CryptoTap from './projects/CryptoTap.js';
+import Gremlin from './projects/Gremlin.js';
 /** Main application component wiring the router. */
 function App() {
     return (React.createElement(HashRouter, null,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,16 +2,16 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import { HashRouter, Routes, Route } from 'react-router-dom';
-import Header from './components/Header';
-import Navbar from './components/Navbar';
-import Footer from './components/Footer';
-import Home from './pages/Home';
-import About from './pages/About';
-import Blog from './pages/Blog';
-import Contact from './pages/Contact';
-import GreyNet from './projects/GreyNet';
-import CryptoTap from './projects/CryptoTap';
-import Gremlin from './projects/Gremlin';
+import Header from './components/Header.js';
+import Navbar from './components/Navbar.js';
+import Footer from './components/Footer.js';
+import Home from './pages/Home.js';
+import About from './pages/About.js';
+import Blog from './pages/Blog.js';
+import Contact from './pages/Contact.js';
+import GreyNet from './projects/GreyNet.js';
+import CryptoTap from './projects/CryptoTap.js';
+import Gremlin from './projects/Gremlin.js';
 
 /** Main application component wiring the router. */
 function App() {

--- a/src/local-modules.d.ts
+++ b/src/local-modules.d.ts
@@ -1,0 +1,41 @@
+// (c) 2025 Asymmetric Effort, LLC. All Rights Reserved.
+declare module './components/Header.js' {
+  import Header from './components/Header';
+  export default Header;
+}
+declare module './components/Navbar.js' {
+  import Navbar from './components/Navbar';
+  export default Navbar;
+}
+declare module './components/Footer.js' {
+  import Footer from './components/Footer';
+  export default Footer;
+}
+declare module './pages/Home.js' {
+  import Home from './pages/Home';
+  export default Home;
+}
+declare module './pages/About.js' {
+  import About from './pages/About';
+  export default About;
+}
+declare module './pages/Blog.js' {
+  import Blog from './pages/Blog';
+  export default Blog;
+}
+declare module './pages/Contact.js' {
+  import Contact from './pages/Contact';
+  export default Contact;
+}
+declare module './projects/GreyNet.js' {
+  import GreyNet from './projects/GreyNet';
+  export default GreyNet;
+}
+declare module './projects/CryptoTap.js' {
+  import CryptoTap from './projects/CryptoTap';
+  export default CryptoTap;
+}
+declare module './projects/Gremlin.js' {
+  import Gremlin from './projects/Gremlin';
+  export default Gremlin;
+}


### PR DESCRIPTION
## Summary
- include `.js` extension on client imports to prevent browser 404s
- stub modules in TypeScript so compilation succeeds

## Testing
- `npm test`
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_b_68858d9e18208332b7a30dcf8122fb77