### PR TITLE
Add import validation test

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "asymmetric-effort",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/test-blog.js"
+    "test": "node tests/test-blog.js && node tests/test-dist-imports.js"
   }
 }

--- a/tests/test-dist-imports.js
+++ b/tests/test-dist-imports.js
@@ -1,0 +1,30 @@
+// (c) 2025 Asymmetric Effort, LLC. All Rights Reserved.
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+/**
+ * Validate that all import paths in dist/index.js include the .js extension and
+ * that the referenced modules exist on disk. This prevents 404 errors when the
+ * browser attempts to load modules by ensuring each import target is available.
+ */
+function validateImports() {
+  const indexPath = path.join(__dirname, '..', 'dist', 'index.js');
+  const text = fs.readFileSync(indexPath, 'utf8');
+  const importRegex = /import\s+[^'"\n]+from\s+'(\.\/[^']+)'/g;
+  let match;
+  const seen = [];
+  while ((match = importRegex.exec(text)) !== null) {
+    const importPath = match[1];
+    // Ensure the import includes the .js extension.
+    assert.ok(importPath.endsWith('.js'), `${importPath} missing .js extension`);
+    const filePath = path.join(__dirname, '..', 'dist', importPath);
+    seen.push(filePath);
+    // Ensure the referenced file exists.
+    assert.ok(fs.existsSync(filePath), `${filePath} does not exist`);
+  }
+  assert.ok(seen.length > 0, 'No imports found to validate');
+  console.log('Import validation passed');
+}
+
+validateImports();


### PR DESCRIPTION
## Summary
- add test checking that dist imports exist with `.js` extension
- update `npm test` script to run new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68858eb315248332b24f46d17c139dfa