### PR TITLE
Switch router to BrowserRouter

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 // (c) 2025 Asymmetric Effort, LLC. All Rights Reserved.
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { HashRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Header from './components/Header.js';
 import Navbar from './components/Navbar.js';
 import Footer from './components/Footer.js';
@@ -14,7 +14,7 @@ import CryptoTap from './projects/CryptoTap.js';
 import Gremlin from './projects/Gremlin.js';
 /** Main application component wiring the router. */
 function App() {
-    return (React.createElement(HashRouter, null,
+    return (React.createElement(BrowserRouter, null,
         React.createElement(Header, null),
         React.createElement(Navbar, null),
         React.createElement(Routes, null,

--- a/package.json
+++ b/package.json
@@ -2,6 +2,6 @@
   "name": "asymmetric-effort",
   "version": "1.0.0",
   "scripts": {
-    "test": "node tests/test-blog.js"
+    "test": "node tests/test-blog.js && node tests/test-dist-imports.js && node tests/test-router.js"
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 // (c) 2025 Asymmetric Effort, LLC. All Rights Reserved.
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import { HashRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import Header from './components/Header.js';
 import Navbar from './components/Navbar.js';
 import Footer from './components/Footer.js';
@@ -16,7 +16,7 @@ import Gremlin from './projects/Gremlin.js';
 /** Main application component wiring the router. */
 function App() {
   return (
-    <HashRouter>
+    <BrowserRouter>
       <Header />
       <Navbar />
       <Routes>
@@ -29,7 +29,7 @@ function App() {
         <Route path="/projects/gremlin" element={<Gremlin />} />
       </Routes>
       <Footer />
-    </HashRouter>
+    </BrowserRouter>
   );
 }
 

--- a/tests/test-dist-imports.js
+++ b/tests/test-dist-imports.js
@@ -1,0 +1,61 @@
+// (c) 2025 Asymmetric Effort, LLC. All Rights Reserved.
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+
+/**
+ * Recursively gather all JavaScript files under a directory.
+ *
+ * @param {string} dir - Directory to search.
+ * @returns {string[]} Array of JS file paths.
+ */
+function collectJsFiles(dir) {
+  const files = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const resolved = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectJsFiles(resolved));
+    } else if (entry.isFile() && resolved.endsWith('.js')) {
+      files.push(resolved);
+    }
+  }
+  return files;
+}
+
+/**
+ * Validate that all relative import paths in the dist directory include the
+ * `.js` extension and reference files that exist on disk. Checking every file
+ * helps prevent browser 404 errors for missing modules.
+ */
+function validateImports() {
+  const distDir = path.join(__dirname, '..', 'dist');
+  const jsFiles = collectJsFiles(distDir);
+  const importRegex = /import\s+[^'"\n]+from\s+['"]([^'"]+)['"]/g;
+  let checked = 0;
+
+  for (const file of jsFiles) {
+    const text = fs.readFileSync(file, 'utf8');
+    let match;
+    while ((match = importRegex.exec(text)) !== null) {
+      const importPath = match[1];
+      if (importPath.startsWith('./') || importPath.startsWith('../')) {
+        assert.ok(
+          importPath.endsWith('.js'),
+          `${file}: ${importPath} missing .js extension`
+        );
+
+        const resolved = path.resolve(path.dirname(file), importPath);
+        assert.ok(
+          fs.existsSync(resolved),
+          `${file}: ${resolved} does not exist`
+        );
+        checked++;
+      }
+    }
+  }
+
+  assert.ok(checked > 0, 'No relative imports found to validate');
+  console.log('Import validation passed');
+}
+
+validateImports();

--- a/tests/test-router.js
+++ b/tests/test-router.js
@@ -1,0 +1,14 @@
+// (c) 2025 Asymmetric Effort, LLC. All Rights Reserved.
+const fs = require('fs');
+const assert = require('assert');
+
+/**
+ * Ensure the compiled app uses BrowserRouter so routes work without hashes.
+ */
+function validateRouter() {
+  const indexJs = fs.readFileSync('dist/index.js', 'utf8');
+  assert.ok(indexJs.includes('BrowserRouter'), 'BrowserRouter not configured');
+  console.log('Router validation passed');
+}
+
+validateRouter();


### PR DESCRIPTION
## Summary
- switch from HashRouter to BrowserRouter so routes resolve without hash fragments
- regenerate `dist/index.js`
- add router validation test
- update test script to run the new check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68858eb315248332b24f46d17c139dfa